### PR TITLE
Fixed Portrange

### DIFF
--- a/src/net/kronos/rkon/core/Rcon.java
+++ b/src/net/kronos/rkon/core/Rcon.java
@@ -50,7 +50,7 @@ public class Rcon {
 			throw new IllegalArgumentException("Host can't be null or empty");
 		}
 		
-		if(port < 0 || port > 65535) {
+		if(port < 1 || port > 65535) {
 			throw new IllegalArgumentException("Port is out of range");
 		}
 		


### PR DESCRIPTION
Port 0 is a reserved Port. When you try to specify that port as a query-port the system either uses a random free port or wouldn't even let you set it to 0 saying its out of range
