### PR TITLE
Changed length of payload

### DIFF
--- a/src/net/kronos/rkon/core/RconPacket.java
+++ b/src/net/kronos/rkon/core/RconPacket.java
@@ -122,7 +122,7 @@ public class RconPacket {
 			int type = buffer.getInt();
 			
 			// Payload size can be computed now that we have its length
-			byte[] payload = new byte[length - 4 - 4 - 2];
+			byte[] payload = new byte[length - 4 - 4 - 4 - 2];
 			
 			DataInputStream dis = new DataInputStream(in);
 			


### PR DESCRIPTION
The body (payload) of the packet does not contain the length (- 4), requestID (- 4), the type (- 4), or the two null bytes (- 2). The original did not account for one of the length, requestID, or the type.